### PR TITLE
Added type support

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,4 @@
+import MarkdownIt from 'markdown-it';
+
+declare const namedCodeBlocks: MarkdownIt.PluginSimple;
+export default namedCodeBlocks;


### PR DESCRIPTION
Hey cool package!
Added some type safety to it.

I can type the default export as `any` instead of `MarkdownIt.PluginSimple` and it won't make a difference. Depends on preference.